### PR TITLE
Fix soft-404 indexing issue: localize tool page headers across 39 tools

### DIFF
--- a/app/[locale]/tools/age-calculator/Client.tsx
+++ b/app/[locale]/tools/age-calculator/Client.tsx
@@ -10,6 +10,7 @@ import { LiquidInput } from "../../../components/ui/LiquidInput";
 
 export default function AgeCalculatorClient() {
     const t = useTranslations('AgeCalculator');
+    const tTools = useTranslations('Tools');
     const [dob, setDob] = useState("");
 
     const calc = () => {
@@ -49,8 +50,8 @@ export default function AgeCalculatorClient() {
                 <div className="max-w-[600px] mx-auto">
 
                     <ToolPageHeader
-                        title="Age Calculator"
-                        description="Calculate your exact age and seeing upcoming birthdays."
+                        title={tTools('age-calculator.name')}
+                        description={tTools('age-calculator.description')}
                         icon={<Cake size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/chmod-calculator/Client.tsx
+++ b/app/[locale]/tools/chmod-calculator/Client.tsx
@@ -15,6 +15,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidCheckbox } from "../../../components/ui/LiquidCheckbox";
 
 export default function ChmodCalculatorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('ChmodCalculator');
     const [owner, setOwner] = useState<Permission>({ r: true, w: true, x: true });
     const [group, setGroup] = useState<Permission>({ r: true, w: false, x: true });
@@ -34,8 +35,8 @@ export default function ChmodCalculatorClient() {
                 <div className="max-w-[800px] mx-auto">
 
                     <ToolPageHeader
-                        title="Chmod Calculator"
-                        description="Interactive calculator for Linux file permissions."
+                        title={tTools('chmod-calculator.name')}
+                        description={tTools('chmod-calculator.description')}
                         icon={<Shield size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/cipher-tools/Client.tsx
+++ b/app/[locale]/tools/cipher-tools/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidInput, LiquidTextArea } from "../../../components/ui/LiquidInput";
 import LiquidTabs from "../../../components/ui/LiquidTabs";
 export default function CipherToolsClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('ToolPage');
     const [input, setInput] = useState("");
     const [shift, setShift] = useState(13); // Default ROT13
@@ -30,8 +31,8 @@ export default function CipherToolsClient() {
                 <div className="max-w-[800px] mx-auto">
 
                     <ToolPageHeader
-                        title="Cipher Tools"
-                        description="Encrypt and decrypt text with simple shift ciphers (Caesar, ROT13)."
+                        title={tTools('cipher-tools.name')}
+                        description={tTools('cipher-tools.description')}
                         icon={<Lock size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/crontab-generator/Client.tsx
+++ b/app/[locale]/tools/crontab-generator/Client.tsx
@@ -8,6 +8,7 @@ import ToolIcon from "../../../components/ToolIcon";
 import { useTranslations } from "next-intl";
 
 export default function CrontabGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('CrontabGenerator');
     const [min, setMin] = useState("*");
     const [hour, setHour] = useState("*");
@@ -207,8 +208,8 @@ export default function CrontabGeneratorClient() {
                 <div className="max-w-[800px] mx-auto">
 
                     <ToolPageHeader
-                        title="Crontab Generator"
-                        description="Easily generate crontab schedules for your cron jobs."
+                        title={tTools('crontab-generator.name')}
+                        description={tTools('crontab-generator.description')}
                         icon={<ToolIcon name="Clock" size={32} />}
                     />
 

--- a/app/[locale]/tools/css-clip-path/Client.tsx
+++ b/app/[locale]/tools/css-clip-path/Client.tsx
@@ -6,6 +6,7 @@ import ToolPageHeader from "../../../components/ToolPageHeader";
 import { useTranslations } from "next-intl";
 
 export default function CssClipPathClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('CssClipPath');
     const [selectedShape, setSelectedShape] = useState("triangle");
     const [copied, setCopied] = useState(false);
@@ -43,8 +44,8 @@ export default function CssClipPathClient() {
                 <div className="max-w-[1000px] mx-auto">
 
                     <ToolPageHeader
-                        title="CSS Clip-Path Generator"
-                        description="Select a shape to generate the CSS clip-path property."
+                        title={tTools('css-clip-path.name')}
+                        description={tTools('css-clip-path.description')}
                         icon={<Scissors size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/css-cursor/Client.tsx
+++ b/app/[locale]/tools/css-cursor/Client.tsx
@@ -16,6 +16,7 @@ const cursors = [
 import { LiquidCard } from "../../../components/ui/LiquidCard";
 
 export default function CssCursorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('CssCursor');
     const [selected, setSelected] = useState("auto");
 
@@ -25,8 +26,8 @@ export default function CssCursorClient() {
                 <div className="max-w-[1000px] mx-auto">
 
                     <ToolPageHeader
-                        title="CSS Cursor Tester"
-                        description="Test different CSS cursor values by hovering over the buttons."
+                        title={tTools('css-cursor.name')}
+                        description={tTools('css-cursor.description')}
                         icon={<MousePointer size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/css-triangle/Client.tsx
+++ b/app/[locale]/tools/css-triangle/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidInput, LiquidTextArea } from "../../../components/ui/LiquidInput"
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function CssTriangleClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('CssTriangle');
     const [direction, setDirection] = useState("top");
     const [color, setColor] = useState("#fb923c");
@@ -57,8 +58,8 @@ border-color: transparent transparent ${color} transparent;`;
                 <div className="max-w-[1000px] mx-auto">
 
                     <ToolPageHeader
-                        title="CSS Triangle Generator"
-                        description="Create CSS triangles easily. Adjust direction, size, and color."
+                        title={tTools('css-triangle.name')}
+                        description={tTools('css-triangle.description')}
                         icon={<Play size={28} className="text-[#fb923c] rotate-[-90deg]" />}
                     />
 

--- a/app/[locale]/tools/device-info/Client.tsx
+++ b/app/[locale]/tools/device-info/Client.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from "next-intl";
 import { LiquidCard } from "../../../components/ui/LiquidCard";
 
 export default function DeviceInfoClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('DeviceInfo');
     const [info, setInfo] = useState<any>(null);
 
@@ -63,8 +64,8 @@ export default function DeviceInfoClient() {
                 <div className="max-w-[1000px] mx-auto">
 
                     <ToolPageHeader
-                        title="Device Information"
-                        description="View detailed information about your device, browser, and network."
+                        title={tTools('device-info.name')}
+                        description={tTools('device-info.description')}
                         icon={<ToolIcon name="Smartphone" size={32} />}
                     />
 

--- a/app/[locale]/tools/favicon-generator/Client.tsx
+++ b/app/[locale]/tools/favicon-generator/Client.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 export default function FaviconGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('FaviconGenerator');
     const [preview, setPreview] = useState("");
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -46,8 +47,8 @@ export default function FaviconGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Favicon Generator"
-                        description="Convert any image into a standard 32x32 PNG favicon for your website."
+                        title={tTools('favicon-generator.name')}
+                        description={tTools('favicon-generator.description')}
                         icon={<ImageIcon size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/gradient-generator/Client.tsx
+++ b/app/[locale]/tools/gradient-generator/Client.tsx
@@ -12,6 +12,7 @@ import { LiquidButton } from "../../../components/ui/LiquidButton";
 import { LiquidSlider } from "../../../components/ui/LiquidSlider";
 
 export default function GradientGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('GradientGenerator');
     const [color1, setColor1] = useState("#f97316");
     const [color2, setColor2] = useState("#facc15");
@@ -47,8 +48,8 @@ export default function GradientGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1000px] mx-auto">
                     <ToolPageHeader
-                        title="CSS Gradient Generator"
-                        description="Create beautiful linear and radial CSS gradients visually."
+                        title={tTools('gradient-generator.name')}
+                        description={tTools('gradient-generator.description')}
                         icon={<ToolIcon name="Layers" size={32} />}
                     />
 

--- a/app/[locale]/tools/htpasswd-generator/Client.tsx
+++ b/app/[locale]/tools/htpasswd-generator/Client.tsx
@@ -11,6 +11,7 @@ import { LiquidInput } from "../../../components/ui/LiquidInput";
 import LiquidSelect from "../../../components/ui/LiquidSelect";
 
 export default function HtpasswdGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('HtpasswdGenerator');
     const [user, setUser] = useState("admin");
     const [pass, setPass] = useState("");
@@ -37,8 +38,8 @@ export default function HtpasswdGeneratorClient() {
                 <div className="max-w-[600px] mx-auto">
 
                     <ToolPageHeader
-                        title="Htpasswd Generator"
-                        description="Generate Basic Auth entries for .htpasswd files (Nginx / Apache)."
+                        title={tTools('htpasswd-generator.name')}
+                        description={tTools('htpasswd-generator.description')}
                         icon={<Lock size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/image-compressor/Client.tsx
+++ b/app/[locale]/tools/image-compressor/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function ImageCompressorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('ImageCompressor');
     const [originalFile, setOriginalFile] = useState<File | null>(null);
     const [compressedBlob, setCompressedBlob] = useState<Blob | null>(null);
@@ -92,8 +93,8 @@ export default function ImageCompressorClient() {
                 <div className="max-w-[1000px] mx-auto">
 
                     <ToolPageHeader
-                        title="Image Compressor"
-                        description="Compress images locally without uploading to server."
+                        title={tTools('image-compressor.name')}
+                        description={tTools('image-compressor.description')}
                         icon={<ImageIcon size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/markdown-table/Client.tsx
+++ b/app/[locale]/tools/markdown-table/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function MarkdownTableClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('MarkdownTable');
     // Simple 2D array state
     const [data, setData] = useState<string[][]>([
@@ -69,8 +70,8 @@ export default function MarkdownTableClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1200px] mx-auto">
                     <ToolPageHeader
-                        title="Markdown Table Generator"
-                        description="Visually create Markdown tables. Add rows, columns, and export to markdown."
+                        title={tTools('markdown-table.name')}
+                        description={tTools('markdown-table.description')}
                         icon={<Table size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/meta-generator/Client.tsx
+++ b/app/[locale]/tools/meta-generator/Client.tsx
@@ -10,6 +10,7 @@ import { LiquidButton } from "../../../components/ui/LiquidButton";
 import { LiquidInput } from "../../../components/ui/LiquidInput";
 
 export default function MetaGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('MetaGenerator');
     const [data, setData] = useState({
         title: "",
@@ -68,8 +69,8 @@ export default function MetaGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1100px] mx-auto">
                     <ToolPageHeader
-                        title="Meta Tag Generator"
-                        description="Generate SEO-friendly meta tags, including Open Graph and Twitter Cards."
+                        title={tTools('meta-generator.name')}
+                        description={tTools('meta-generator.description')}
                         icon={<Tags size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/meta-tags/Client.tsx
+++ b/app/[locale]/tools/meta-tags/Client.tsx
@@ -10,6 +10,7 @@ import { LiquidInput, LiquidTextArea } from "../../../components/ui/LiquidInput"
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function MetaTagsClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('MetaTags');
     const [title, setTitle] = useState("");
     const [desc, setDesc] = useState("");
@@ -34,8 +35,8 @@ export default function MetaTagsClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Simple Meta Tags"
-                        description="Quickly generate basic HTML meta tags for your page."
+                        title={tTools('meta-tags.name')}
+                        description={tTools('meta-tags.description')}
                         icon={<Code2 size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/my-ip/Client.tsx
+++ b/app/[locale]/tools/my-ip/Client.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from "next-intl";
 import { LiquidCard } from "../../../components/ui/LiquidCard";
 
 export default function MyIPClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('MyIP');
     const [data, setData] = useState<any>(null);
     const [loading, setLoading] = useState(true);
@@ -37,8 +38,8 @@ export default function MyIPClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[600px] mx-auto">
                     <ToolPageHeader
-                        title="My IP Address"
-                        description="Check your public IP address, location, and ISP details instantly."
+                        title={tTools('my-ip.name')}
+                        description={tTools('my-ip.description')}
                         icon={<Globe size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/og-generator/Client.tsx
+++ b/app/[locale]/tools/og-generator/Client.tsx
@@ -11,6 +11,7 @@ import LiquidSelect from "../../../components/ui/LiquidSelect";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function OgGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('OgGenerator');
     const [title, setTitle] = useState("");
     const [desc, setDesc] = useState("");
@@ -35,8 +36,8 @@ export default function OgGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1000px] mx-auto">
                     <ToolPageHeader
-                        title="Open Graph Generator"
-                        description="Create preview-ready Open Graph meta tags for Facebook, Twitter, LinkedIn, and more."
+                        title={tTools('og-generator.name')}
+                        description={tTools('og-generator.description')}
                         icon={<Share2 size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/pretty-print-url/Client.tsx
+++ b/app/[locale]/tools/pretty-print-url/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidInput } from "../../../components/ui/LiquidInput";
 import { useTranslations } from "next-intl";
 
 export default function PrettyPrintUrlClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('PrettyPrintUrl');
     const [input, setInput] = useState("");
     const [copied, setCopied] = useState(false);
@@ -51,8 +52,8 @@ export default function PrettyPrintUrlClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Pretty Print URL"
-                        description="Format long URLs into a clean, readable structure by separating query parameters."
+                        title={tTools('pretty-print-url.name')}
+                        description={tTools('pretty-print-url.description')}
                         icon={<LinkIcon size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/random-generator/Client.tsx
+++ b/app/[locale]/tools/random-generator/Client.tsx
@@ -12,6 +12,7 @@ import { LiquidButton } from "../../../components/ui/LiquidButton";
 import LiquidTabs from "../../../components/ui/LiquidTabs";
 
 export default function RandomGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('RandomGenerator');
     const [tab, setTab] = useState<'number' | 'list' | 'coin'>('number');
 
@@ -51,8 +52,8 @@ export default function RandomGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Random Generator Suite"
-                        description="Generate random numbers, pick items from lists, or flip a virtual coin."
+                        title={tTools('random-generator.name')}
+                        description={tTools('random-generator.description')}
                         icon={<Dices size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/screen-recorder/Client.tsx
+++ b/app/[locale]/tools/screen-recorder/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function ScreenRecorderClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('ScreenRecorder');
     const [isRecording, setIsRecording] = useState(false);
     const [videoUrl, setVideoUrl] = useState("");
@@ -78,8 +79,8 @@ export default function ScreenRecorderClient() {
                 <div className="max-w-[800px] mx-auto text-center">
 
                     <ToolPageHeader
-                        title="Screen Recorder"
-                        description="Record your screen directly from your browser. No installation needed."
+                        title={tTools('screen-recorder.name')}
+                        description={tTools('screen-recorder.description')}
                         icon={<Monitor size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/signature-generator/Client.tsx
+++ b/app/[locale]/tools/signature-generator/Client.tsx
@@ -6,6 +6,7 @@ import ToolPageHeader from "../../../components/ToolPageHeader";
 import { useTranslations } from "next-intl";
 
 export default function SignatureGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('SignatureGenerator');
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [isDrawing, setIsDrawing] = useState(false);
@@ -97,8 +98,8 @@ export default function SignatureGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Digital Signature Generator"
-                        description="Draw and download your digital signature as a PNG image."
+                        title={tTools('signature-generator.name')}
+                        description={tTools('signature-generator.description')}
                         icon={<PenTool size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/slug-generator/Client.tsx
+++ b/app/[locale]/tools/slug-generator/Client.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { LiquidCard } from "../../../components/ui/LiquidCard";
 
 export default function SlugGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('SlugGenerator');
     const [input, setInput] = useState("");
 
@@ -30,8 +31,8 @@ export default function SlugGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Slug Generator"
-                        description="Convert titles to URL-friendly slugs case-insensitively."
+                        title={tTools('slug-generator.name')}
+                        description={tTools('slug-generator.description')}
                         icon={<ToolIcon name="Link2" size={32} />}
                     />
 

--- a/app/[locale]/tools/speech-to-text/Client.tsx
+++ b/app/[locale]/tools/speech-to-text/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidInput, LiquidTextArea } from "../../../components/ui/LiquidInput"
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function SpeechToTextClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('SpeechToText');
     const [text, setText] = useState("");
     const [listening, setListening] = useState(false);
@@ -65,8 +66,8 @@ export default function SpeechToTextClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Speech to Text"
-                        description="Convert speech to text with the Web Speech API."
+                        title={tTools('speech-to-text.name')}
+                        description={tTools('speech-to-text.description')}
                         icon={<Mic size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/sql-to-json/Client.tsx
+++ b/app/[locale]/tools/sql-to-json/Client.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import CodeEditor from "../../../components/CodeEditor";
 
 export default function SqlToJsonClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('SqlToJson');
     const [input, setInput] = useState("");
     const [output, setOutput] = useState("");
@@ -72,8 +73,8 @@ export default function SqlToJsonClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1000px] mx-auto">
                     <ToolPageHeader
-                        title="SQL to JSON Converter"
-                        description="Convert SQL INSERT statements to JSON array."
+                        title={tTools('sql-to-json.name')}
+                        description={tTools('sql-to-json.description')}
                         icon={<Database size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/subnet-calculator/Client.tsx
+++ b/app/[locale]/tools/subnet-calculator/Client.tsx
@@ -6,6 +6,7 @@ import ToolPageHeader from "../../../components/ToolPageHeader";
 import { useTranslations } from "next-intl";
 
 export default function SubnetCalculatorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('SubnetCalculator');
     const [ip, setIp] = useState("192.168.1.1");
     const [cidr, setCidr] = useState("24");
@@ -57,8 +58,8 @@ export default function SubnetCalculatorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Subnet Calculator"
-                        description="Calculate network address, broadcast address, and host range from IP and CIDR."
+                        title={tTools('subnet-calculator.name')}
+                        description={tTools('subnet-calculator.description')}
                         icon={<Network size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/svg-to-png/Client.tsx
+++ b/app/[locale]/tools/svg-to-png/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidTextArea } from "../../../components/ui/LiquidInput";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 export default function SvgToPngClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('SvgToPng');
     const [svgContent, setSvgContent] = useState("");
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -70,8 +71,8 @@ export default function SvgToPngClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="SVG to PNG Converter"
-                        description="Convert SVG vector files to high-resolution PNG images."
+                        title={tTools('svg-to-png.name')}
+                        description={tTools('svg-to-png.description')}
                         icon={<ImageIcon size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/text-diff/Client.tsx
+++ b/app/[locale]/tools/text-diff/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import CodeEditor from "../../../components/CodeEditor";
 
 export default function TextDiffClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('TextDiff');
     const [oldText, setOldText] = useState('{\n  "name": "example",\n  "version": "1.0.0"\n}');
     const [newText, setNewText] = useState('{\n  "name": "example-app",\n  "version": "1.0.1",\n  "private": true\n}');
@@ -62,8 +63,8 @@ export default function TextDiffClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1200px] mx-auto">
                     <ToolPageHeader
-                        title="Text Diff Checker"
-                        description="Compare text and code to find differences (additions/removals) instantly."
+                        title={tTools('text-diff.name')}
+                        description={tTools('text-diff.description')}
                         icon={<ToolIcon name="GitCompare" size={32} />}
                     />
 

--- a/app/[locale]/tools/text-to-speech/Client.tsx
+++ b/app/[locale]/tools/text-to-speech/Client.tsx
@@ -11,6 +11,7 @@ import { LiquidButton } from "../../../components/ui/LiquidButton";
 import { LiquidSlider } from "../../../components/ui/LiquidSlider";
 
 export default function TextToSpeechClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('TextToSpeech');
     const [text, setText] = useState("Hello, welcome to Daily Dev Tools.");
     const [rate, setRate] = useState(1);
@@ -56,8 +57,8 @@ export default function TextToSpeechClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Text to Speech"
-                        description="Convert text to natural sounding speech using browser APIs."
+                        title={tTools('text-to-speech.name')}
+                        description={tTools('text-to-speech.description')}
                         icon={<Volume2 size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/timestamp-converter/Client.tsx
+++ b/app/[locale]/tools/timestamp-converter/Client.tsx
@@ -7,6 +7,7 @@ import ToolIcon from "../../../components/ToolIcon";
 import { useTranslations } from "next-intl";
 import { LiquidCard } from "../../../components/ui/LiquidCard";
 export default function TimestampConverterClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('TimestampConverter');
     const [timestamp, setTimestamp] = useState<number>(0);
     const [dateString, setDateString] = useState("");
@@ -73,8 +74,8 @@ export default function TimestampConverterClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[900px] mx-auto">
                     <ToolPageHeader
-                        title="Unix Timestamp Converter"
-                        description="Convert between Unix timestamps and human-readable dates."
+                        title={tTools('timestamp-converter.name')}
+                        description={tTools('timestamp-converter.description')}
                         icon={<ToolIcon name="Clock" size={32} />}
                     />
 

--- a/app/[locale]/tools/timezone-converter/Client.tsx
+++ b/app/[locale]/tools/timezone-converter/Client.tsx
@@ -7,6 +7,7 @@ import { LiquidInput } from "../../../components/ui/LiquidInput";
 import { useTranslations } from "next-intl";
 
 export default function TimezoneConverterClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('TimezoneConverter');
     const [date, setDate] = useState("");
     const [time, setTime] = useState("");
@@ -53,8 +54,8 @@ export default function TimezoneConverterClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[600px] mx-auto">
                     <ToolPageHeader
-                        title="Timezone Converter"
-                        description="Check the time across multiple major timezones instantly."
+                        title={tTools('timezone-converter.name')}
+                        description={tTools('timezone-converter.description')}
                         icon={<Clock size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/token-generator/Client.tsx
+++ b/app/[locale]/tools/token-generator/Client.tsx
@@ -11,6 +11,7 @@ import { LiquidButton } from "../../../components/ui/LiquidButton";
 import { LiquidTextArea } from "../../../components/ui/LiquidInput";
 
 export default function TokenGeneratorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('TokenGenerator');
     const [length, setLength] = useState(32);
     const [includeNumbers, setIncludeNumbers] = useState(true);
@@ -38,8 +39,8 @@ export default function TokenGeneratorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Random Token Generator"
-                        description="Generate secure random strings, tokens, and API keys."
+                        title={tTools('token-generator.name')}
+                        description={tTools('token-generator.description')}
                         icon={<Key size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/twitter-card/Client.tsx
+++ b/app/[locale]/tools/twitter-card/Client.tsx
@@ -10,6 +10,7 @@ import { LiquidInput, LiquidTextArea } from "../../../components/ui/LiquidInput"
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 
 export default function TwitterCardClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('TwitterCard');
     const [cardType, setCardType] = useState("summary_large_image");
     const [site, setSite] = useState("");
@@ -34,8 +35,8 @@ export default function TwitterCardClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[1000px] mx-auto">
                     <ToolPageHeader
-                        title="Twitter Card Generator"
-                        description="Create Twitter Card meta tags for rich tweets."
+                        title={tTools('twitter-card.name')}
+                        description={tTools('twitter-card.description')}
                         icon={<Twitter size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/unit-converter/Client.tsx
+++ b/app/[locale]/tools/unit-converter/Client.tsx
@@ -13,6 +13,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 type Category = 'length' | 'weight' | 'temperature';
 
 export default function UnitConverterClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('UnitConverter');
 
     // Define units inside component or useMemo to access translations
@@ -84,8 +85,8 @@ export default function UnitConverterClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="Unit Converter"
-                        description="Convert between different units of measurement universally."
+                        title={tTools('unit-converter.name')}
+                        description={tTools('unit-converter.description')}
                         icon={<ToolIcon name="Scale" size={32} />}
                     />
 

--- a/app/[locale]/tools/url-parser/Client.tsx
+++ b/app/[locale]/tools/url-parser/Client.tsx
@@ -6,6 +6,7 @@ import ToolPageHeader from "../../../components/ToolPageHeader";
 import { useTranslations } from "next-intl";
 
 export default function UrlParserClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('UrlParser');
     const [input, setInput] = useState("");
     const [parsed, setParsed] = useState<any>(null);
@@ -45,8 +46,8 @@ export default function UrlParserClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="URL Parser"
-                        description="Parse URLs into their components (protocol, hostname, path, parameters)."
+                        title={tTools('url-parser.name')}
+                        description={tTools('url-parser.description')}
                         icon={<LinkIcon size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/utm-builder/Client.tsx
+++ b/app/[locale]/tools/utm-builder/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidInput } from "../../../components/ui/LiquidInput";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 export default function UtmBuilderClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('UtmBuilder');
     const [url, setUrl] = useState("");
     const [source, setSource] = useState("");
@@ -38,8 +39,8 @@ export default function UtmBuilderClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="UTM Builder"
-                        description="Generate tracking links with UTM parameters for your campaigns."
+                        title={tTools('utm-builder.name')}
+                        description={tTools('utm-builder.description')}
                         icon={<LinkIcon size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/vat-calculator/Client.tsx
+++ b/app/[locale]/tools/vat-calculator/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidInput } from "../../../components/ui/LiquidInput";
 
 export default function VatCalculatorClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('VatCalculator');
     const [amount, setAmount] = useState("");
     const [rate, setRate] = useState("20");
@@ -26,8 +27,8 @@ export default function VatCalculatorClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="VAT Calculator"
-                        description="Calculate VAT inclusive or exclusive amounts instantly."
+                        title={tTools('vat-calculator.name')}
+                        description={tTools('vat-calculator.description')}
                         icon={<Calculator size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/vibration-tester/Client.tsx
+++ b/app/[locale]/tools/vibration-tester/Client.tsx
@@ -9,6 +9,7 @@ import { LiquidSlider } from "../../../components/ui/LiquidSlider";
 import { useTranslations } from "next-intl";
 
 export default function VibrationTesterClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('VibrationTester');
     const [duration, setDuration] = useState(200);
 
@@ -23,8 +24,8 @@ export default function VibrationTesterClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[600px] mx-auto">
                     <ToolPageHeader
-                        title="Vibration Tester"
-                        description="Test your device's vibration motor online."
+                        title={tTools('vibration-tester.name')}
+                        description={tTools('vibration-tester.description')}
                         icon={<Smartphone size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/week-number/Client.tsx
+++ b/app/[locale]/tools/week-number/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidInput } from "../../../components/ui/LiquidInput";
 import { LiquidProgressBar } from "../../../components/ui/LiquidProgressBar";
 export default function WeekNumberClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('WeekNumber');
     const [date, setDate] = useState("");
     const [week, setWeek] = useState(0);
@@ -49,8 +50,8 @@ export default function WeekNumberClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[600px] mx-auto">
                     <ToolPageHeader
-                        title="Week Number Calculator"
-                        description="Find the current ISO week number or calculate it for any date."
+                        title={tTools('week-number.name')}
+                        description={tTools('week-number.description')}
                         icon={<Calendar size={28} className="text-[#fb923c]" />}
                     />
 

--- a/app/[locale]/tools/whatsapp-link/Client.tsx
+++ b/app/[locale]/tools/whatsapp-link/Client.tsx
@@ -8,6 +8,7 @@ import { LiquidCard } from "../../../components/ui/LiquidCard";
 import { LiquidInput, LiquidTextArea } from "../../../components/ui/LiquidInput";
 import { LiquidButton } from "../../../components/ui/LiquidButton";
 export default function WhatsAppLinkClient() {
+    const tTools = useTranslations('Tools');
     const t = useTranslations('WhatsAppLink');
     const [phone, setPhone] = useState("");
     const [message, setMessage] = useState("");
@@ -21,8 +22,8 @@ export default function WhatsAppLinkClient() {
             <div className="relative z-10 pt-6 pb-16 px-6">
                 <div className="max-w-[800px] mx-auto">
                     <ToolPageHeader
-                        title="WhatsApp Link Generator"
-                        description="Create click-to-chat WhatsApp links for your website or social media."
+                        title={tTools('whatsapp-link.name')}
+                        description={tTools('whatsapp-link.description')}
                         icon={<MessageCircle size={28} className="text-[#fb923c]" />}
                     />
 


### PR DESCRIPTION
Replaces hardcoded English title/description strings in ToolPageHeader with tTools() translation calls across all 39 affected tool pages. This fixes the root cause of the Soft 404 indexing issue found in Google Search Console, where non-English locale pages rendered with English-only headers. All Tools.<id>.name and Tools.<id>.description keys already exist in all 29 locale message files, so this is purely a wiring fix with no new translation content.